### PR TITLE
Fix issue torchmetrics F1 -> F1Score

### DIFF
--- a/recipes/dcase2022_task4_baseline/local/sed_trainer.py
+++ b/recipes/dcase2022_task4_baseline/local/sed_trainer.py
@@ -113,13 +113,13 @@ class SEDTask4(pl.LightningModule):
             raise NotImplementedError
 
         # for weak labels we simply compute f1 score
-        self.get_weak_student_f1_seg_macro = torchmetrics.classification.f_beta.F1(
+        self.get_weak_student_f1_seg_macro = torchmetrics.classification.f_beta.F1Score(
             len(self.encoder.labels),
             average="macro",
             compute_on_step=False,
         )
 
-        self.get_weak_teacher_f1_seg_macro = torchmetrics.classification.f_beta.F1(
+        self.get_weak_teacher_f1_seg_macro = torchmetrics.classification.f_beta.F1Score(
             len(self.encoder.labels),
             average="macro",
             compute_on_step=False,


### PR DESCRIPTION
From issue #47 

From the commit in the 9th of January in pytorch lightning: https://github.com/PyTorchLightning/metrics/commit/c20860ae8924776281b6d36a781dcf458d62438d

I suggest to put the requirements to torchmetrics >= 0.8.1 :)

Would it make sense to you ? 
