### PR TITLE
DCASE Task 4 2024 baseline update, bug fixing

### DIFF
--- a/recipes/dcase2024_task4_baseline/README.md
+++ b/recipes/dcase2024_task4_baseline/README.md
@@ -157,13 +157,13 @@ In detail:
 
 Dataset | **PSDS-scenario1** | **PSDS-scenario1 (sed score)** | **mean pAUC**     | 
 --------|--------------------|--------------------------------|-------------------|
-Dev-test| **0.48 +- 0.003**  | **0.49 +- 0.004**              | **0.69 +- 0.006** | 
+Dev-test| **0.48 +- 0.003**  | **0.49 +- 0.004**              | **0.73 +- 0.007** | 
 
 **Energy Consumption** (GPU: NVIDIA A100 40Gb on a single DGX A100 machine)
 
 Dataset | Training           | Dev-Test          |
 --------|--------------------|-------------------|
-**kWh** | **1.174 +- 0.141** | **0.143 +- 0.04** | 
+**kWh** | **1.666 +- 0.125** | **0.143 +- 0.04** | 
 
 
 Collar-based = event-based. More information about the metrics in the [DCASE Challenge webpage][dcase_webpage].

--- a/recipes/dcase2024_task4_baseline/local/classes_dict.py
+++ b/recipes/dcase2024_task4_baseline/local/classes_dict.py
@@ -68,7 +68,7 @@ classes_labels_maestro_real_eval = {
 }
 
 maestro_desed_alias = {
-    "people_talking": "Speech",
+    "people talking": "Speech",
     "children voices": "Speech",  # both synth and real
     "announcement": "Speech",
     "cutlery and dishes": "Dishes",

--- a/recipes/dcase2024_task4_baseline/local/sed_trainer_pretrained.py
+++ b/recipes/dcase2024_task4_baseline/local/sed_trainer_pretrained.py
@@ -1336,13 +1336,6 @@ class SEDTask4(pl.LightningModule):
             {"/train/tot_energy_kWh": torch.tensor(float(training_kwh))}
         )
 
-        os.makedirs(os.path.join(self.exp_dir, "training_codecarbon"), exist_ok=True)
-        with open(
-            os.path.join(self.exp_dir, "training_codecarbon", "training_tot_kwh.txt"),
-            "w",
-        ) as f:
-            f.write(str(training_kwh))
-
     def on_test_start(self) -> None:
         if self.evaluation:
             os.makedirs(os.path.join(self.exp_dir, "codecarbon"), exist_ok=True)

--- a/recipes/dcase2024_task4_baseline/train_pretrained.py
+++ b/recipes/dcase2024_task4_baseline/train_pretrained.py
@@ -337,6 +337,7 @@ def single_run(
             feats_pipeline=feature_extraction,
             embeddings_hdf5_file=get_embeddings_name(config, "synth_train"),
             embedding_type=config["net"]["embedding_type"],
+            mask_events_other_than=mask_events_desed,
         )
 
         strong_df = pd.read_csv(config["data"]["strong_tsv"], sep="\t")
@@ -348,7 +349,7 @@ def single_run(
             feats_pipeline=feature_extraction,
             embeddings_hdf5_file=get_embeddings_name(config, "strong_train"),
             embedding_type=config["net"]["embedding_type"],
-            mask_events_other_than=mask_events_desed,
+            mask_events_other_than=mask_events_desed
         )
 
         weak_df = pd.read_csv(config["data"]["weak_tsv"], sep="\t")


### PR DESCRIPTION
fixing bugs pointed out by @apple-yinhan and @fschmid56. 
In particular, line https://github.com/DCASE-REPO/DESED_task/blob/678404858b28aa747a4029ce03c983013fca8ac6/recipes/dcase2024_task4_baseline/train_pretrained.py#L332 missed the masking mask, this affected the performance quite a bit. 

Solves also issue https://github.com/DCASE-REPO/DESED_task/issues/97. 

New performance: 

Dataset | **PSDS-scenario1** | **PSDS-scenario1 (sed score)** | **mean pAUC**     | 
--------|--------------------|--------------------------------|-------------------|
Dev-test| **0.48 +- 0.003**  | **0.49 +- 0.004**              | **0.73 +- 0.007** | 


